### PR TITLE
Computes time by looking at the output

### DIFF
--- a/src/NLPModelsIpopt.jl
+++ b/src/NLPModelsIpopt.jl
@@ -10,6 +10,7 @@ Solves the `NLPModel` problem `nlp` using `IpOpt`.
 """
 function ipopt(nlp :: AbstractNLPModel;
                callback :: Union{Function,Nothing} = nothing,
+               ignore_time :: Bool = false,
                kwargs...)
   n, m = nlp.meta.nvar, nlp.meta.ncon
   eval_f(x) = obj(nlp, x)
@@ -51,22 +52,48 @@ function ipopt(nlp :: AbstractNLPModel;
                           eval_jac_g, eval_h)
   problem.x = copy(nlp.meta.x0)
 
+  print_output = true
+
   # Options
   for (k,v) in kwargs
-    addOption(problem, string(k), v)
+    if ignore_time || k != :print_level || v ≥ 3
+      addOption(problem, string(k), v)
+    else
+      if v > 0
+        @warn("`print_level` should be 0 or ≥ 3 to get the elapsed time, if you don't care about the elapsed time, pass `ignore_time=true`")
+      end
+      print_output = false
+      addOption(problem, "print_level", 3)
+    end
   end
 
   # Callback
   callback === nothing || setIntermediateCallback(problem, callback)
 
-  status = solveProblem(problem)
+  tmpfile = tempname()
+  local status
+  open(tmpfile, "w") do io
+    redirect_stdout(io) do
+      status = solveProblem(problem)
+    end
+  end
+  ipopt_output = readlines(tmpfile)
+
+  cpu_time_lines = filter(line->occursin("CPU secs", line), ipopt_output)
+  Δt = 0.0
+  for line in cpu_time_lines
+    Δt += Meta.parse(split(line, "=")[2])
+  end
+  if print_output
+    println(join(ipopt_output, "\n"))
+  end
   x  = problem.x
   c  = problem.g
   λ  = problem.mult_g
   zL = problem.mult_x_L
   zU = problem.mult_x_U
   f  = problem.obj_val
-  return x, f, c, λ, zL, zU, Ipopt.ApplicationReturnStatus[status]
+  return x, f, c, λ, zL, zU, Ipopt.ApplicationReturnStatus[status], Δt
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,23 +2,23 @@ using NLPModelsIpopt, NLPModels, Ipopt, Test
 
 function tests()
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
-  x, f, c, λ, zL, zU, status = ipopt(nlp)
+  x, f, c, λ, zL, zU, status, Δt = ipopt(nlp)
   @test isapprox(x, [1.0; 1.0], rtol=1e-6)
 
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - 3)^2, zeros(2),
                    c=x->[sum(x) - 1.0], lcon=[0.0], ucon=[0.0])
-  x, f, c, λ, zL, zU, status = ipopt(nlp)
+  x, f, c, λ, zL, zU, status, Δt = ipopt(nlp)
   @test isapprox(x, [-1.4; 2.4], rtol=1e-6)
 
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
-  x, f, c, λ, zL, zU, status = ipopt(nlp, tol=1e-12)
+  x, f, c, λ, zL, zU, status, Δt = ipopt(nlp, tol=1e-12)
   @test isapprox(x, [1.0; 1.0], rtol=1e-6)
 
   function callback(alg_mod, iter_count, args...)
     return iter_count < 1
   end
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
-  x, f, c, λ, zL, zU, status = ipopt(nlp, tol=1e-12, callback=callback)
+  x, f, c, λ, zL, zU, status, Δt = ipopt(nlp, tol=1e-12, callback=callback)
   @test status == :User_Requested_Stop
 end
 


### PR DESCRIPTION
A few hacks to get the time from the output of IPOPT.
- `print_level` needs to be at least 3 to print time;
- If `print_level` is less than 3, we use a higher `print_level` but do not show the user the output of IPOPT;
- If the user really wants `print_level` less than 3, he can use `ignore_time=true`.