### PR TITLE
use in-place structure methods

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -120,10 +120,12 @@ function NLPModels.grad!(nlp :: LogisticRegression, β::AbstractVector, g::Abstr
   g .= nlp.X' * (hβ .- nlp.y) + nlp.λ * β
 end
 
-function NLPModels.hess_structure(nlp :: LogisticRegression)
+function NLPModels.hess_structure!(nlp :: LogisticRegression, rows :: AbstractVector{<:Integer}, cols :: AbstractVector{<:Integer})
   n = nlp.meta.nvar
   I = ((i,j) for i = 1:n, j = 1:n if i ≥ j)
-  return [getindex.(I, 1); 1:n], [getindex.(I, 2); 1:n]
+  rows[1 : nlp.meta.nnzh] .= [getindex.(I, 1); 1:n]
+  cols[1 : nlp.meta.nnzh] .= [getindex.(I, 2); 1:n]
+  return rows, cols
 end
 
 function NLPModels.hess_coord!(nlp :: LogisticRegression, β::AbstractVector, rows::AbstractVector{<: Integer}, cols::AbstractVector{<: Integer}, vals::AbstractVector; obj_weight=1.0, y=Float64[])

--- a/src/NLPModelsIpopt.jl
+++ b/src/NLPModelsIpopt.jl
@@ -32,7 +32,6 @@ function ipopt(nlp :: AbstractNLPModel;
                callback :: Union{Function,Nothing} = nothing,
                kwargs...)
   n, m = nlp.meta.nvar, nlp.meta.ncon
-  local jrows, jcols, hrows, hcols
 
   eval_f(x) = obj(nlp, x)
   eval_g(x, g) = m > 0 ? cons!(nlp, x, g) : zeros(0)
@@ -40,23 +39,19 @@ function ipopt(nlp :: AbstractNLPModel;
   eval_jac_g(x, mode, rows::Vector{Int32}, cols::Vector{Int32}, values) = begin
     nlp.meta.ncon == 0 && return
     if mode == :Structure
-      jrows, jcols = jac_structure(nlp)
-      rows .= jrows
-      cols .= jcols
+      jac_structure!(nlp, rows, cols)
     else
-      jac_coord!(nlp, x, jrows, jcols, values)
+      jac_coord!(nlp, x, rows, cols, values)
     end
   end
   eval_h(x, mode, rows::Vector{Int32}, cols::Vector{Int32}, σ, λ, values) = begin
     if mode == :Structure
-      hrows, hcols = hess_structure(nlp)
-      rows .= hrows
-      cols .= hcols
+      hess_structure!(nlp, rows, cols)
     else
       if nlp.meta.ncon > 0
-        hess_coord!(nlp, x, hrows, hcols, values, obj_weight=σ, y=λ)
+        hess_coord!(nlp, x, rows, cols, values, obj_weight=σ, y=λ)
       else
-        hess_coord!(nlp, x, hrows, hcols, values, obj_weight=σ)
+        hess_coord!(nlp, x, rows, cols, values, obj_weight=σ)
       end
     end
   end


### PR DESCRIPTION
The tests should fail because this requires https://github.com/JuliaSmoothOptimizers/NLPModels.jl/pull/191 (i.e., a new version of NLPModels). Similar fixes will be coming for CUTEst.jl and AmplNLReader.jl.