### PR TITLE
Use NLPModels 0.12 on docs and update Version to 0.3.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NLPModelsIpopt"
 uuid = "f4238b75-b362-5c4c-b852-0801c9a21d71"
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -9,4 +9,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]
 Documenter = "~0.24"
-NLPModels = "0.10.0, 1"
+NLPModels = "0.12"


### PR DESCRIPTION
- ~Change Julia version on CI~
- Use NLPModels 0.12 on docs
- Update to version 0.3.2 for new release