### PR TITLE
test more platforms and architectures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,16 @@
+freebsd_instance:
+  image: freebsd-12-1-release-amd64
+task:
+  name: FreeBSD
+  env:
+    matrix:
+      - JULIA_VERSION: 1.0
+      - JULIA_VERSION: 1
+      - JULIA_VERSION: nightly
+  allow_failures: $JULIA_VERSION == 'nightly'
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - cirrusjl test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ os:
   - linux
   - osx
   - windows
+  - freebsd
+
+arch:
+  - x64
+  - amd64
+  # - ppc64le
+  - arm64
 
 julia:
   - 1.0


### PR DESCRIPTION
Ipopt.jl 0.6.2 now uses the Yggdrasil binaries, which are available for almost anything under the sun.