### PR TITLE
Add maximization problems

### DIFF
--- a/src/NLPModelsIpopt.jl
+++ b/src/NLPModelsIpopt.jl
@@ -113,6 +113,10 @@ function ipopt(nlp :: AbstractNLPModel;
     end
   end
 
+  if !nlp.meta.minimize
+    addOption(problem, "obj_scaling_factor", -1.0)
+  end
+
   if ipopt_log_to_file
     0 < ipopt_file_log_level < 3 && @warn("`file_print_level` should be 0 or ≥ 3 for IPOPT to report elapsed time, final residuals and number of iterations")
   else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,15 @@ function tests()
   @test isapprox(stats.multipliers_U, zU, rtol=1e-6)
   @test stats.iter == 0
   @test stats.status == :first_order
+
+  meta = NLPModelMeta(1, x0 = rand(1), lvar = zeros(1), uvar = ones(1), minimize = false)
+  nlp = ADNLPModel(meta, Counters(), ADNLPModels.ForwardDiffAD(), x -> x[1], x -> [])
+  stats = ipopt(nlp)
+  @test isapprox(stats.solution, ones(1), rtol=1e-6)
+  @test isapprox(stats.objective, 1.0, rtol=1e-6)
+  @test isapprox(stats.multipliers_L, zeros(1), atol=1e-6)
+  @test isapprox(stats.multipliers_U, -ones(1), rtol=1e-6)
+  @test stats.status == :first_order
 end
 
 tests()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,18 +2,18 @@ using ADNLPModels, NLPModelsIpopt, NLPModels, Ipopt, Test
 
 function tests()
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
-  stats = ipopt(nlp)
+  stats = ipopt(nlp, print_level=0)
   @test isapprox(stats.solution, [1.0; 1.0], rtol=1e-6)
   @test stats.status == :first_order
 
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
-  stats = ipopt(nlp, tol=1e-12)
+  stats = ipopt(nlp, tol=1e-12, print_level=0)
   @test isapprox(stats.solution, [1.0; 1.0], rtol=1e-6)
   @test stats.status == :first_order
 
   # solve again from solution
   x0 = copy(stats.solution)
-  stats = ipopt(nlp, x0=x0, tol=1e-12)
+  stats = ipopt(nlp, x0=x0, tol=1e-12, print_level=0)
   @test isapprox(stats.solution, x0, rtol=1e-6)
   @test stats.status == :first_order
   @test stats.iter == 0
@@ -22,14 +22,14 @@ function tests()
     return iter_count < 1
   end
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
-  stats = ipopt(nlp, tol=1e-12, callback=callback)
+  stats = ipopt(nlp, tol=1e-12, callback=callback, print_level=0)
   @test stats.status == :user
   @test stats.solver_specific[:internal_msg] == :User_Requested_Stop
   @test stats.iter == 1
 
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - 3)^2, zeros(2),
                    x->[sum(x) - 1.0], [0.0], [0.0])
-  stats = ipopt(nlp)
+  stats = ipopt(nlp, print_level=0)
   @test isapprox(stats.solution, [-1.4; 2.4], rtol=1e-6)
   @test stats.iter == 1
   @test stats.status == :first_order
@@ -39,7 +39,7 @@ function tests()
   y0 = copy(stats.multipliers)
   zL = copy(stats.multipliers_L)
   zU = copy(stats.multipliers_U)
-  stats = ipopt(nlp, x0=x0, y0=y0, zL0=zL, zU0=zU)
+  stats = ipopt(nlp, x0=x0, y0=y0, zL0=zL, zU0=zU, print_level=0)
   @test isapprox(stats.solution, x0, rtol=1e-6)
   @test isapprox(stats.multipliers, y0, rtol=1e-6)
   @test isapprox(stats.multipliers_L, zL, rtol=1e-6)
@@ -47,9 +47,9 @@ function tests()
   @test stats.iter == 0
   @test stats.status == :first_order
 
-  meta = NLPModelMeta(1, x0 = rand(1), lvar = zeros(1), uvar = ones(1), minimize = false)
+  meta = NLPModelMeta(1, x0=rand(1), lvar=zeros(1), uvar=ones(1), minimize=false)
   nlp = ADNLPModel(meta, Counters(), ADNLPModels.ForwardDiffAD(), x -> x[1], x -> [])
-  stats = ipopt(nlp)
+  stats = ipopt(nlp, print_level=0)
   @test isapprox(stats.solution, ones(1), rtol=1e-6)
   @test isapprox(stats.objective, 1.0, rtol=1e-6)
   @test isapprox(stats.multipliers_L, zeros(1), atol=1e-6)


### PR DESCRIPTION
Following what is done in [Ipopt.jl L1360](https://github.com/jump-dev/Ipopt.jl/blob/ed23b493a3ee33359d9ccd537a97530cdfca5848/src/MOI_wrapper.jl#L1360), we now handle maximization problems.

Connected to the discussion in [NLPModels.jl issue 341](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/issues/341).

Additionally removed the prints from the tests.