### PR TITLE
Bump to NLPModels 0.15 and co

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,8 @@ SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
 
 [compat]
 Ipopt = "0.5.0, 0.6"
-NLPModels = "0.14"
-SolverCore = "0.1"
+NLPModels = "0.14, 0.15"
+SolverCore = "0.1, 0.2"
 julia = "^1.3.0"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,7 @@ function tests()
   @test stats.status == :first_order
 
   meta = NLPModelMeta(1, x0 = rand(1), lvar = zeros(1), uvar = ones(1), minimize = false)
-  nlp = ADNLPModel(meta, Counters(), ADNLPModels.ForwardDiffAD(), x -> x[1], x -> [])
+  nlp = ADNLPModel(meta, Counters(), ADNLPModels.ForwardDiffAD(1), x -> x[1], x -> [])
   stats = ipopt(nlp, print_level = 0)
   @test isapprox(stats.solution, ones(1), rtol = 1e-6)
   @test isapprox(stats.objective, 1.0, rtol = 1e-6)


### PR DESCRIPTION
Follows [NLPModels.jl PR #353](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/pull/353) with parametric meta.

The update of ADNLPModels breaks the test, but not the package so I didn't drop 0.14.