### PR TITLE
Depend on Ipopt_jll.jl directly instead of Ipopt.jl

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,8 @@ task:
         image_family: freebsd-13-3
       env:
         matrix:
-          - JULIA_VERSION: 1
+          - JULIA_VERSION: 'lts'
+          - JULIA_VERSION: '1'
   install_script: |
     URL="https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh"
     set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,26 +13,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        version: ['lts', '1']
+        os: [ubuntu-latest, macos-latest, windows-latest]
         arch: [x64]
         allow_failure: [false]
         include:
-          - version: 'nightly'
+          - version: '1'
+            os: ubuntu-24.04-arm
+            arch: arm64
+            allow_failure: false
+          - version: '1'
+            os: macos-latest
+            arch: arm64
+            allow_failure: false
+          - version: 'pre'
             os: ubuntu-latest
             arch: x64
             allow_failure: true
-          - version: 'nightly'
+          - version: 'pre'
             os: macOS-latest
             arch: x64
             allow_failure: true
-          - version: 'nightly'
+          - version: 'pre'
             os: windows-latest
             arch: x64
             allow_failure: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/Project.toml
+++ b/Project.toml
@@ -3,15 +3,19 @@ uuid = "f4238b75-b362-5c4c-b852-0801c9a21d71"
 version = "0.10.2"
 
 [deps]
-Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
+OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
 
 [compat]
-Ipopt = "0.9, 1"
-NLPModels = "0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
+Ipopt_jll = "=300.1400.1700"
+LinearAlgebra = "1.10"
+NLPModels = "0.21.3"
+OpenBLAS32_jll = "0.3.24"
 SolverCore = "0.3"
-julia = "^1.6"
+julia = "1.10"
 
 [extras]
 ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"

--- a/src/C_wrapper.jl
+++ b/src/C_wrapper.jl
@@ -1,0 +1,471 @@
+# Copyright (c) 2013: Iain Dunning, Miles Lubin, and contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+mutable struct IpoptProblem
+    ipopt_problem::Ptr{Cvoid}   # Reference to the internal data structure
+    n::Int                      # Num vars
+    m::Int                      # Num cons
+    x::Vector{Float64}          # Starting and final solution
+    g::Vector{Float64}          # Final constraint values
+    mult_g::Vector{Float64}     # lagrange multipliers on constraints
+    mult_x_L::Vector{Float64}   # lagrange multipliers on lower bounds
+    mult_x_U::Vector{Float64}   # lagrange multipliers on upper bounds
+    obj_val::Float64            # Final objective
+    status::Cint                # Final status
+    # Callbacks
+    eval_f::Function
+    eval_g::Function
+    eval_grad_f::Function
+    eval_jac_g::Function
+    eval_h::Union{Function,Nothing}
+    intermediate::Union{Function,Nothing}
+end
+
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, p::IpoptProblem) = p.ipopt_problem
+
+function _Eval_F_CB(
+    n::Cint,
+    x_ptr::Ptr{Float64},
+    x_new::Cint,
+    obj_value::Ptr{Float64},
+    user_data::Ptr{Cvoid},
+)
+    prob = unsafe_pointer_to_objref(user_data)::IpoptProblem
+    x = unsafe_wrap(Array, x_ptr, Int(n))
+    if x_new == Cint(1)
+        prob.x .= x
+    end
+    new_obj = convert(Float64, prob.eval_f(x))::Float64
+    unsafe_store!(obj_value, new_obj)
+    return Cint(1)
+end
+
+function _Eval_Grad_F_CB(
+    n::Cint,
+    x_ptr::Ptr{Float64},
+    # A Bool indicating if `x` is a new point. We don't make use of this.
+    ::Cint,
+    grad_f::Ptr{Float64},
+    user_data::Ptr{Cvoid},
+)
+    prob = unsafe_pointer_to_objref(user_data)::IpoptProblem
+    new_grad_f = unsafe_wrap(Array, grad_f, Int(n))
+    x = unsafe_wrap(Array, x_ptr, Int(n))
+    prob.eval_grad_f(x, new_grad_f)
+    return Cint(1)
+end
+
+function _Eval_G_CB(
+    n::Cint,
+    x_ptr::Ptr{Float64},
+    x_new::Cint,
+    m::Cint,
+    g_ptr::Ptr{Float64},
+    user_data::Ptr{Cvoid},
+)
+    prob = unsafe_pointer_to_objref(user_data)::IpoptProblem
+    new_g = unsafe_wrap(Array, g_ptr, Int(m))
+    x = unsafe_wrap(Array, x_ptr, Int(n))
+    if x_new == Cint(1)
+        prob.x .= x
+    end
+    prob.eval_g(x, new_g)
+    return Cint(1)
+end
+
+function _Eval_Jac_G_CB(
+    n::Cint,
+    x_ptr::Ptr{Float64},
+    ::Cint,
+    ::Cint,
+    nele_jac::Cint,
+    iRow::Ptr{Cint},
+    jCol::Ptr{Cint},
+    values_ptr::Ptr{Float64},
+    user_data::Ptr{Cvoid},
+)
+    prob = unsafe_pointer_to_objref(user_data)::IpoptProblem
+    x = unsafe_wrap(Array, x_ptr, Int(n))
+    rows = unsafe_wrap(Array, iRow, Int(nele_jac))
+    cols = unsafe_wrap(Array, jCol, Int(nele_jac))
+    if values_ptr == C_NULL
+        prob.eval_jac_g(x, rows, cols, nothing)
+    else
+        values = unsafe_wrap(Array, values_ptr, Int(nele_jac))
+        prob.eval_jac_g(x, rows, cols, values)
+    end
+    return Cint(1)
+end
+
+function _Eval_H_CB(
+    n::Cint,
+    x_ptr::Ptr{Float64},
+    ::Cint,
+    obj_factor::Float64,
+    m::Cint,
+    lambda_ptr::Ptr{Float64},
+    ::Cint,
+    nele_hess::Cint,
+    iRow::Ptr{Cint},
+    jCol::Ptr{Cint},
+    values_ptr::Ptr{Float64},
+    user_data::Ptr{Cvoid},
+)
+    prob = unsafe_pointer_to_objref(user_data)::IpoptProblem
+    if prob.eval_h === nothing
+        # No hessian. Return FALSE for failure.
+        return Cint(0)
+    end
+    x = unsafe_wrap(Array, x_ptr, Int(n))
+    lambda = unsafe_wrap(Array, lambda_ptr, Int(m))
+    rows = unsafe_wrap(Array, iRow, Int(nele_hess))
+    cols = unsafe_wrap(Array, jCol, Int(nele_hess))
+    if values_ptr == C_NULL
+        prob.eval_h(x, rows, cols, obj_factor, lambda, nothing)
+    else
+        values = unsafe_wrap(Array, values_ptr, Int(nele_hess))
+        prob.eval_h(x, rows, cols, obj_factor, lambda, values)
+    end
+    return Cint(1)  # Return TRUE for success.
+end
+
+function _Intermediate_CB(
+    alg_mod::Cint,
+    iter_count::Cint,
+    obj_value::Float64,
+    inf_pr::Float64,
+    inf_du::Float64,
+    mu::Float64,
+    d_norm::Float64,
+    regularization_size::Float64,
+    alpha_du::Float64,
+    alpha_pr::Float64,
+    ls_trials::Cint,
+    user_data::Ptr{Cvoid},
+)
+    prob = unsafe_pointer_to_objref(user_data)::IpoptProblem
+    ret = prob.intermediate(
+        alg_mod,
+        iter_count,
+        obj_value,
+        inf_pr,
+        inf_du,
+        mu,
+        d_norm,
+        regularization_size,
+        alpha_du,
+        alpha_pr,
+        ls_trials,
+    )
+    # Return TRUE if the optimization should continue.
+    return ret ? Cint(1) : Cint(0)
+end
+
+function CreateIpoptProblem(
+    n::Int,
+    x_L::Vector{Float64},
+    x_U::Vector{Float64},
+    m::Int,
+    g_L::Vector{Float64},
+    g_U::Vector{Float64},
+    nele_jac::Int,
+    nele_hess::Int,
+    eval_f,
+    eval_g,
+    eval_grad_f,
+    eval_jac_g,
+    eval_h,
+)
+    @assert n == length(x_L) == length(x_U)
+    @assert m == length(g_L) == length(g_U)
+    eval_f_cb = @cfunction(
+        _Eval_F_CB,
+        Cint,
+        (Cint, Ptr{Float64}, Cint, Ptr{Float64}, Ptr{Cvoid}),
+    )
+    eval_g_cb = @cfunction(
+        _Eval_G_CB,
+        Cint,
+        (Cint, Ptr{Float64}, Cint, Cint, Ptr{Float64}, Ptr{Cvoid}),
+    )
+    eval_grad_f_cb = @cfunction(
+        _Eval_Grad_F_CB,
+        Cint,
+        (Cint, Ptr{Float64}, Cint, Ptr{Float64}, Ptr{Cvoid}),
+    )
+    eval_jac_g_cb = @cfunction(
+        _Eval_Jac_G_CB,
+        Cint,
+        (
+            Cint,
+            Ptr{Float64},
+            Cint,
+            Cint,
+            Cint,
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Float64},
+            Ptr{Cvoid},
+        ),
+    )
+    eval_h_cb = @cfunction(
+        _Eval_H_CB,
+        Cint,
+        (
+            Cint,
+            Ptr{Float64},
+            Cint,
+            Float64,
+            Cint,
+            Ptr{Float64},
+            Cint,
+            Cint,
+            Ptr{Cint},
+            Ptr{Cint},
+            Ptr{Float64},
+            Ptr{Cvoid},
+        ),
+    )
+    ipopt_problem = @ccall libipopt.CreateIpoptProblem(
+        n::Cint,
+        x_L::Ptr{Cdouble},
+        x_U::Ptr{Cdouble},
+        m::Cint,
+        g_L::Ptr{Cdouble},
+        g_U::Ptr{Cdouble},
+        nele_jac::Cint,
+        nele_hess::Cint,
+        1::Cint,  # 1 = Fortran style indexing
+        eval_f_cb::Ptr{Cvoid},
+        eval_g_cb::Ptr{Cvoid},
+        eval_grad_f_cb::Ptr{Cvoid},
+        eval_jac_g_cb::Ptr{Cvoid},
+        eval_h_cb::Ptr{Cvoid},
+    )::Ptr{Cvoid}
+    if ipopt_problem == C_NULL
+        if n == 0
+            error(
+                "IPOPT: Failed to construct problem because there are 0 " *
+                "variables. If you intended to construct an empty problem, " *
+                "one work-around is to add a variable fixed to 0.",
+            )
+        else
+            error("IPOPT: Failed to construct problem for some unknown reason.")
+        end
+    end
+    prob = IpoptProblem(
+        ipopt_problem,
+        n,
+        m,
+        zeros(Float64, n),
+        zeros(Float64, m),
+        zeros(Float64, m),
+        zeros(Float64, n),
+        zeros(Float64, n),
+        0.0,
+        0,
+        eval_f,
+        eval_g,
+        eval_grad_f,
+        eval_jac_g,
+        eval_h,
+        nothing,
+    )
+    finalizer(FreeIpoptProblem, prob)
+    return prob
+end
+
+function FreeIpoptProblem(prob::IpoptProblem)
+    @ccall libipopt.FreeIpoptProblem(prob::Ptr{Cvoid})::Cvoid
+    return
+end
+
+function AddIpoptStrOption(prob::IpoptProblem, keyword::String, value::String)
+    if !(isascii(keyword) && isascii(value))
+        error("IPOPT: Non ASCII parameters not supported")
+    end
+    ret = @ccall libipopt.AddIpoptStrOption(
+        prob::Ptr{Cvoid},
+        keyword::Ptr{UInt8},
+        value::Ptr{UInt8},
+    )::Bool
+    if !ret
+        error("IPOPT: Couldn't set option '$keyword' to value '$value'.")
+    end
+    return
+end
+
+function AddIpoptNumOption(prob::IpoptProblem, keyword::String, value::Float64)
+    if !isascii(keyword)
+        error("IPOPT: Non ASCII parameters not supported")
+    end
+    ret = @ccall libipopt.AddIpoptNumOption(
+        prob::Ptr{Cvoid},
+        keyword::Ptr{UInt8},
+        value::Cdouble,
+    )::Bool
+    if !ret
+        error("IPOPT: Couldn't set option '$keyword' to value '$value'.")
+    end
+    return
+end
+
+function AddIpoptIntOption(prob::IpoptProblem, keyword::String, value::Integer)
+    if !isascii(keyword)
+        error("IPOPT: Non ASCII parameters not supported")
+    end
+    ret = @ccall libipopt.AddIpoptIntOption(
+        prob::Ptr{Cvoid},
+        keyword::Ptr{UInt8},
+        value::Cint,
+    )::Bool
+    if !ret
+        error(
+            "IPOPT: Couldn't set option '$keyword' to value '$value'::Int32. " *
+            "Note that `Num` options need to be explictly passed as " *
+            "`Float64($value)` instead of their integer equivalents.",
+        )
+    end
+    return
+end
+
+function OpenIpoptOutputFile(
+    prob::IpoptProblem,
+    file_name::String,
+    print_level::Int,
+)
+    if !isascii(file_name)
+        error("IPOPT: Non ASCII parameters not supported")
+    end
+    ret = @ccall libipopt.OpenIpoptOutputFile(
+        prob::Ptr{Cvoid},
+        file_name::Ptr{UInt8},
+        print_level::Cint,
+    )::Bool
+    if !ret
+        error("IPOPT: Couldn't open output file.")
+    end
+    return
+end
+
+function SetIpoptProblemScaling(
+    prob::IpoptProblem,
+    obj_scaling::Float64,
+    x_scaling::Union{Ptr{Cvoid},Vector{Float64}},
+    g_scaling::Union{Ptr{Cvoid},Vector{Float64}},
+)
+    ret = @ccall libipopt.SetIpoptProblemScaling(
+        prob::Ptr{Cvoid},
+        obj_scaling::Cdouble,
+        x_scaling::Ptr{Cdouble},
+        g_scaling::Ptr{Cdouble},
+    )::Bool
+    @assert ret  # The C++ code has `return true`
+    return
+end
+
+function SetIntermediateCallback(prob::IpoptProblem, intermediate::Function)
+    intermediate_cb = @cfunction(
+        _Intermediate_CB,
+        Cint,
+        (
+            Cint,
+            Cint,
+            Float64,
+            Float64,
+            Float64,
+            Float64,
+            Float64,
+            Float64,
+            Float64,
+            Float64,
+            Cint,
+            Ptr{Cvoid},
+        ),
+    )
+    ret = @ccall libipopt.SetIntermediateCallback(
+        prob::Ptr{Cvoid},
+        intermediate_cb::Ptr{Cvoid},
+    )::Bool
+    @assert ret  # The C++ code has `return true`
+    prob.intermediate = intermediate
+    return
+end
+
+function IpoptSolve(prob::IpoptProblem)
+    p_objval = Ref{Cdouble}(0.0)
+    prob.status = @ccall libipopt.IpoptSolve(
+        prob::Ptr{Cvoid},
+        prob.x::Ptr{Cdouble},
+        prob.g::Ptr{Cdouble},
+        p_objval::Ptr{Cdouble},
+        prob.mult_g::Ptr{Cdouble},
+        prob.mult_x_L::Ptr{Cdouble},
+        prob.mult_x_U::Ptr{Cdouble},
+        pointer_from_objref(prob)::Ptr{Cvoid},
+    )::Cint
+    prob.obj_val = p_objval[]
+    return prob.status
+end
+
+function GetIpoptCurrentIterate(
+    prob::IpoptProblem,
+    scaled::Bool,
+    n::Integer,
+    x::Union{Ptr{Cvoid},Vector{Float64}},
+    z_L::Union{Ptr{Cvoid},Vector{Float64}},
+    z_U::Union{Ptr{Cvoid},Vector{Float64}},
+    m::Integer,
+    g::Union{Ptr{Cvoid},Vector{Float64}},
+    lambda::Union{Ptr{Cvoid},Vector{Float64}},
+)
+    ret = @ccall libipopt.GetIpoptCurrentIterate(
+        prob::Ptr{Cvoid},
+        scaled::Bool,
+        n::Cint,
+        x::Ptr{Cdouble},
+        z_L::Ptr{Cdouble},
+        z_U::Ptr{Cdouble},
+        m::Cint,
+        g::Ptr{Cdouble},
+        lambda::Ptr{Cdouble},
+    )::Bool
+    if !ret
+        error("IPOPT: Something went wrong getting the current iterate.")
+    end
+    return
+end
+
+function GetIpoptCurrentViolations(
+    prob::IpoptProblem,
+    scaled::Bool,
+    n::Integer,
+    x_L_violation::Union{Ptr{Cvoid},Vector{Float64}},
+    x_U_violation::Union{Ptr{Cvoid},Vector{Float64}},
+    compl_x_L::Union{Ptr{Cvoid},Vector{Float64}},
+    compl_x_U::Union{Ptr{Cvoid},Vector{Float64}},
+    grad_lag_x::Union{Ptr{Cvoid},Vector{Float64}},
+    m::Integer,
+    nlp_constraint_violation::Union{Ptr{Cvoid},Vector{Float64}},
+    compl_g::Union{Ptr{Cvoid},Vector{Float64}},
+)
+    ret = @ccall libipopt.GetIpoptCurrentViolations(
+        prob::Ptr{Cvoid},
+        scaled::Bool,
+        n::Cint,
+        x_L_violation::Ptr{Cdouble},
+        x_U_violation::Ptr{Cdouble},
+        compl_x_L::Ptr{Cdouble},
+        compl_x_U::Ptr{Cdouble},
+        grad_lag_x::Ptr{Cdouble},
+        m::Cint,
+        nlp_constraint_violation::Ptr{Cdouble},
+        compl_g::Ptr{Cdouble},
+    )::Bool
+    if !ret
+        error("IPOPT: Something went wrong getting the current violations.")
+    end
+    return
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ADNLPModels, NLPModelsIpopt, NLPModels, Ipopt, SolverCore, Test
+using ADNLPModels, NLPModelsIpopt, NLPModels, SolverCore, Test
 
 @testset "Restart NLPModelsIpopt" begin
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])


### PR DESCRIPTION
I spent an eternity the last few days to recompile N times `MathOptInterface`...
We just need the C interface of Ipopt.jl in this package.

We should probably do the same thing with KNITRO.jl.