### PR TITLE
Add JSO-style callback support, tests, and docs

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -126,6 +126,24 @@ solver = IpoptSolver(nlp)
 stats = solve!(solver, nlp, callback = my_callback, print_level = 0)
 ```
 
+### JSO-style callback signature
+
+In addition to the Ipopt-style callback parameters, this package also accepts a simpler JSO-style callback used across JuliaSmoothOptimizers packages:
+
+- `cb(nlp, solver, stats) -> Bool`
+
+Where `nlp` is the `AbstractNLPModel` being solved, `solver` is the internal Ipopt problem/solver handle, and `stats` is the `GenericExecutionStats` object that will be updated during the solve. The callback should return `true` to continue the optimization or `false` to stop (this maps to Ipopt's user-requested stop).
+
+Example:
+
+```@example ex5
+function jso_cb(nlp, solver, stats)
+  println("iter=", stats.iter, " x=", solver.x)
+  return stats.iter < 5
+end
+stats = ipopt(nlp, callback = jso_cb, print_level = 0)
+```
+
 ### Custom stopping criteria
 
 Callbacks are particularly useful for implementing custom stopping criteria:

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -136,7 +136,7 @@ Where `nlp` is the `AbstractNLPModel` being solved, `solver` is the internal Ipo
 
 Example:
 
-```@example ex5
+```@example ex4
 function jso_cb(nlp, solver, stats)
   println("iter=", stats.iter, " x=", solver.x)
   return stats.iter < 5

--- a/src/NLPModelsIpopt.jl
+++ b/src/NLPModelsIpopt.jl
@@ -307,20 +307,29 @@ function SolverCore.solve!(
   )
     set_residuals!(stats, inf_pr, inf_du)
     set_iter!(stats, Int(iter_count))
-    return callback(
-      alg_mod,
-      iter_count,
-      obj_value,
-      inf_pr,
-      inf_du,
-      mu,
-      d_norm,
-      regularization_size,
-      alpha_du,
-      alpha_pr,
-      ls_trials,
-      args...,
-    )
+    try
+      return callback(nlp, problem, stats)
+    catch err
+      # If the signature doesn't match, fall back to the Ipopt-style callback call.
+      if isa(err, MethodError) || isa(err, ArgumentError)
+        return callback(
+          alg_mod,
+          iter_count,
+          obj_value,
+          inf_pr,
+          inf_du,
+          mu,
+          d_norm,
+          regularization_size,
+          alpha_du,
+          alpha_pr,
+          ls_trials,
+          args...,
+        )
+      else
+        rethrow(err)
+      end
+    end
   end
   SetIntermediateCallback(problem, solver_callback)
 

--- a/src/NLPModelsIpopt.jl
+++ b/src/NLPModelsIpopt.jl
@@ -312,7 +312,6 @@ function SolverCore.solve!(
     # Helper to normalize callback return value
     _to_bool(rv) = (rv === nothing) ? true : Bool(rv)
 
-    # Explicit styles take precedence when set
     if callback_style === :ipopt_full
       return _to_bool(callback(
         alg_mod,
@@ -334,8 +333,6 @@ function SolverCore.solve!(
       return _to_bool(callback(nlp, problem, stats))
     end
 
-    # Auto-detect mode: prefer JSO-style first to align with JSO ecosystem expectations.
-    # 1) JSO-style (nlp, solver, stats)
     try
       return _to_bool(callback(nlp, problem, stats))
     catch err
@@ -343,7 +340,7 @@ function SolverCore.solve!(
         rethrow(err)
       end
     end
-    # 2) Full Ipopt-style (least likely to match accidentally)
+
     try
       return _to_bool(callback(
         alg_mod,
@@ -364,7 +361,6 @@ function SolverCore.solve!(
         rethrow(err)
       end
     end
-    # 3) Short Ipopt-style (3-arg)
     return _to_bool(callback(alg_mod, iter_count, obj_value))
   end
   SetIntermediateCallback(problem, solver_callback)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,18 @@ end
   @test stats.primal_feas ≈ 0.0
   # @test stats.dual_feas ≈ 4.63
 
+  # Test JSO-style callback signature: (nlp, solver, stats) -> Bool
+  function jso_callback(nlp_in, solver_in, stats_in)
+    @test typeof(nlp_in) <: AbstractNLPModel
+    @test hasproperty(stats_in, :iter)
+    return false
+  end
+  nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
+  stats = ipopt(nlp, tol = 1e-12, callback = jso_callback, print_level = 0)
+  @test stats.status == :user
+  @test stats.solver_specific[:internal_msg] == :User_Requested_Stop
+  @test stats.iter >= 0
+
   nlp =
     ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - 3)^2, zeros(2), x -> [sum(x) - 1.0], [0.0], [0.0])
   stats = ipopt(nlp, print_level = 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,19 +65,79 @@ end
   @test stats.primal_feas ≈ 0.0
   # @test stats.dual_feas ≈ 4.63
 
-  # Test JSO-style callback signature: (nlp, solver, stats) -> Bool
-  function jso_callback(nlp_in, solver_in, stats_in)
-    @test typeof(nlp_in) <: AbstractNLPModel
-    @test hasproperty(stats_in, :iter)
-    # stop after 5 iterations
-    println("iter=", stats_in.iter, " x=", solver_in.x)
-    return stats_in.iter < 5
+  @testset "JSO callback stops after 5 iterations" begin
+    function jso_callback(nlp_in, solver_in, stats_in)
+      @test typeof(nlp_in) <: AbstractNLPModel
+      @test hasproperty(stats_in, :iter)
+      return stats_in.iter < 5
+    end
+    nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
+    stats = ipopt(nlp, tol = 1e-12, callback = jso_callback, print_level = 0)
+    @test stats.status == :user
+    @test stats.solver_specific[:internal_msg] == :User_Requested_Stop
+    @test stats.iter == 5
   end
-  nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
-  stats = ipopt(nlp, tol = 1e-12, callback = jso_callback, print_level = 0)
-  @test stats.status == :user
-  @test stats.solver_specific[:internal_msg] == :User_Requested_Stop
-  @test stats.iter == 5
+
+  @testset "JSO callback can read problem and nlp" begin
+    function jso_cb_problem_nlp(nlp_in, solver_in, stats_in)
+      @test typeof(nlp_in) <: AbstractNLPModel
+      @test length(solver_in.x) == nlp_in.meta.nvar
+      if nlp_in.meta.ncon > 0
+        @test length(solver_in.mult_g) == nlp_in.meta.ncon
+      end
+      return stats_in.iter < 3
+    end
+    nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
+    stats = ipopt(nlp, callback = jso_cb_problem_nlp, print_level = 0)
+    @test stats.status == :user
+    @test stats.iter == 3
+  end
+
+  @testset "Short Ipopt-style 3-arg callback" begin
+    function short_cb(alg_mod, iter_count, obj_value)
+      @test isa(alg_mod, Integer)
+      @test iter_count >= 0
+      @test isa(obj_value, Real)
+      return iter_count < 4
+    end
+    nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
+    stats = ipopt(nlp, callback = short_cb, callback_style = :ipopt_short, print_level = 0)
+    @test stats.status == :user
+    @test stats.iter == 4
+  end
+
+  @testset "JSO callback can use solver and nlp" begin
+    used_solver = Ref(false)
+    used_nlp = Ref(false)
+    function jso_cb(nlp_in, solver_in, stats_in)
+      # Use solver.x (problem current iterate)
+      @test length(solver_in.x) == nlp_in.meta.nvar
+      used_solver[] = true
+      # Use nlp to compute objective at current x
+      _ = obj(nlp_in, solver_in.x)
+      used_nlp[] = true
+      return stats_in.iter < 3
+    end
+    nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
+    stats = ipopt(nlp, callback = jso_cb, print_level = 0)
+    @test stats.status == :user
+    @test used_solver[]
+    @test used_nlp[]
+    @test stats.iter == 3
+  end
+
+  @testset "Ipopt-style short callback (3 args)" begin
+    function short_cb(alg_mod, iter_count, obj_value)
+      @test isa(alg_mod, Integer)
+      @test isa(iter_count, Integer)
+      @test isa(obj_value, Real)
+      return iter_count < 2
+    end
+    nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
+    stats = ipopt(nlp, callback = short_cb, callback_style = :ipopt_short, print_level = 0)
+    @test stats.status == :user
+    @test stats.iter == 2
+  end
 
   nlp =
     ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - 3)^2, zeros(2), x -> [sum(x) - 1.0], [0.0], [0.0])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,13 +69,15 @@ end
   function jso_callback(nlp_in, solver_in, stats_in)
     @test typeof(nlp_in) <: AbstractNLPModel
     @test hasproperty(stats_in, :iter)
-    return false
+    # stop after 5 iterations
+    println("iter=", stats_in.iter, " x=", solver_in.x)
+    return stats_in.iter < 5
   end
   nlp = ADNLPModel(x -> (x[1] - 1)^2 + 100 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
   stats = ipopt(nlp, tol = 1e-12, callback = jso_callback, print_level = 0)
   @test stats.status == :user
   @test stats.solver_specific[:internal_msg] == :User_Requested_Stop
-  @test stats.iter >= 0
+  @test stats.iter == 5
 
   nlp =
     ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - 3)^2, zeros(2), x -> [sum(x) - 1.0], [0.0], [0.0])


### PR DESCRIPTION
- NLPModelsIpopt.jl : Try JSO-style callback (nlp, solver, stats) first, fallback to Ipopt-style callback.
- runtests.jl : Added a unit test verifying the JSO-style callback is accepted and can stop the solver.
- tutorial.md : Added documentation and a short example for the JSO-style callback.

Closes #104 